### PR TITLE
feat: add the -n (--newest) option to the process command

### DIFF
--- a/src/pynbox/entrypoints/cli.py
+++ b/src/pynbox/entrypoints/cli.py
@@ -78,8 +78,9 @@ def status(ctx: Context) -> None:
 
 @cli.command()
 @click.argument("type_", required=False, default=None)
+@click.option("-n", "--newest", is_flag=True)
 @click.pass_context
-def process(ctx: Context, type_: Optional[str] = None) -> None:
+def process(ctx: Context, type_: Optional[str] = None, newest: bool = False) -> None:
     """Create a TUI interface to process the elements."""
     console = Console()
     session_start = time.time()
@@ -89,9 +90,10 @@ def process(ctx: Context, type_: Optional[str] = None) -> None:
         Choice(title="Done", shortcut_key="d"),
         Choice(title="Skip", shortcut_key="s"),
         Choice(title="Delete", shortcut_key="e"),
+        Choice(title="Change type", shortcut_key="c"),
         Choice(title="Quit", shortcut_key="q"),
     ]
-    elements = services.elements(repo, config, type_)
+    elements = services.elements(repo, config, type_, newest)
     processed_elements = 0
     for element in elements:
         if element.body is None or element.body == "":
@@ -128,6 +130,12 @@ def process(ctx: Context, type_: Optional[str] = None) -> None:
             processed_elements += 1
         elif choice == "Skip":
             element.skip()
+        elif choice == "Change type":
+            types = services.types(config)
+            choice = select(
+                "Select the new type", choices=types, default=element.type_
+            ).ask()
+            element.type_ = choice
         elif choice == "Quit":
             break
         repo.add(element)

--- a/src/pynbox/services.py
+++ b/src/pynbox/services.py
@@ -164,5 +164,4 @@ def types(config: Config) -> List[str]:
     Returns:
         Ordered list of element types.
     """
-
     return list(config["types"].keys())

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -165,3 +165,46 @@ def test_elements_returns_ordered_items(config: Config, repo: Repository) -> Non
     assert result[1] == elements[3]
     assert result[2] == elements[0]
     assert result[3] == elements[1]
+
+
+def test_elements_returns_ordered_items_when_newest(
+    config: Config, repo: Repository
+) -> None:
+    """
+    Given: Three tasks, of different types_ and creation dates
+    When: elements is called with the newest flag
+    Then: The elements are returned ordered first by priority of type and then by
+        creation date with the newest first.
+    """
+    elements = [
+        Element(
+            description="Low priority and old",
+            type_="idea",
+            created=datetime(2020, 1, 2),
+        ),
+        Element(
+            description="Low priority and new",
+            type_="idea",
+            created=datetime(2020, 2, 2),
+        ),
+        Element(
+            description="High priority and old",
+            type_="task",
+            created=datetime(2020, 1, 1),
+        ),
+        Element(
+            description="High priority and new",
+            type_="task",
+            created=datetime(2020, 2, 1),
+        ),
+    ]
+    for element in elements:
+        repo.add(element)
+    repo.commit()
+
+    result = services.elements(repo, config, newest=True)
+
+    assert result[0] == elements[3]
+    assert result[1] == elements[2]
+    assert result[2] == elements[1]
+    assert result[3] == elements[0]


### PR DESCRIPTION
To process the newest elements first, instead of the oldest

feat: add the change type option to the process command

So if you mistakingly marked an element on the wrong type you can
correct it

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
