### PR TITLE
chore: remove the importlib-metadata patch

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -2,9 +2,6 @@
 name = "argcomplete"
 version = "1.12.3"
 summary = "Bash tab completion for argparse"
-dependencies = [
-    "importlib-metadata<5,>=0.23; python_version == \"3.7\"",
-]
 
 [[package]]
 name = "astor"
@@ -20,15 +17,14 @@ summary = "Pretty print the output of python stdlib `ast.parse`."
 
 [[package]]
 name = "astroid"
-version = "2.6.6"
-requires_python = "~=3.6"
+version = "2.11.7"
+requires_python = ">=3.6.2"
 summary = "An abstract syntax tree for Python with inference support."
 dependencies = [
     "lazy-object-proxy>=1.4.0",
     "setuptools>=20.0",
-    "typed-ast<1.5,>=1.4.0; implementation_name == \"cpython\" and python_version < \"3.8\"",
-    "typing-extensions>=3.7.4; python_version < \"3.8\"",
-    "wrapt<1.13,>=1.11",
+    "typing-extensions>=3.10; python_version < \"3.10\"",
+    "wrapt<2,>=1.11",
 ]
 
 [[package]]
@@ -108,7 +104,6 @@ dependencies = [
     "pathspec>=0.9.0",
     "platformdirs>=2",
     "tomli>=1.1.0; python_full_version < \"3.11.0a7\"",
-    "typed-ast>=1.4.2; python_version < \"3.8\" and implementation_name == \"cpython\"",
     "typing-extensions>=3.10.0.0; python_version < \"3.10\"",
 ]
 
@@ -121,11 +116,6 @@ dependencies = [
     "six>=1.9.0",
     "webencodings",
 ]
-
-[[package]]
-name = "cached-property"
-version = "1.5.2"
-summary = "A decorator for caching properties in classes."
 
 [[package]]
 name = "certifi"
@@ -160,7 +150,6 @@ requires_python = ">=3.7"
 summary = "Composable command line interface toolkit"
 dependencies = [
     "colorama; platform_system == \"Windows\"",
-    "importlib-metadata; python_version < \"3.8\"",
 ]
 
 [[package]]
@@ -240,6 +229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.3.5.1"
+requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
+summary = "serialize all of python"
+
+[[package]]
 name = "distlib"
 version = "0.3.5"
 summary = "Distribution utilities"
@@ -299,7 +294,6 @@ requires_python = ">=3.6"
 summary = "Faker is a Python package that generates fake data for you."
 dependencies = [
     "python-dateutil>=2.4",
-    "typing-extensions>=3.10.0.2; python_version < \"3.8\"",
 ]
 
 [[package]]
@@ -314,7 +308,6 @@ version = "4.0.1"
 requires_python = ">=3.6"
 summary = "the modular source code checker: pep8 pyflakes and co"
 dependencies = [
-    "importlib-metadata<4.3; python_version < \"3.8\"",
     "mccabe<0.7.0,>=0.6.0",
     "pycodestyle<2.9.0,>=2.8.0",
     "pyflakes<2.5.0,>=2.4.0",
@@ -337,7 +330,6 @@ summary = "Flake8 Type Annotation Checks"
 dependencies = [
     "attrs>=21.4",
     "flake8>=3.7",
-    "typed-ast<2.0,>=1.4; python_version < \"3.8\"",
 ]
 
 [[package]]
@@ -366,7 +358,6 @@ requires_python = ">=3.7"
 summary = "A flake8 plugin to help you write better list/set/dict comprehensions."
 dependencies = [
     "flake8!=3.2.0,>=3.0",
-    "importlib-metadata; python_version < \"3.8\"",
 ]
 
 [[package]]
@@ -463,7 +454,6 @@ summary = "flake8 plugin which checks for code that can be simplified"
 dependencies = [
     "astor>=0.1",
     "flake8>=3.7",
-    "importlib-metadata>=0.9; python_version < \"3.8\"",
 ]
 
 [[package]]
@@ -473,7 +463,6 @@ requires_python = ">=3.6.1"
 summary = "flake8 plugin which checks that typing imports are properly guarded"
 dependencies = [
     "flake8>=3.8",
-    "importlib-metadata>=0.9; python_version < \"3.8\"",
 ]
 
 [[package]]
@@ -500,7 +489,6 @@ dependencies = [
     "colorama",
     "entrypoints",
     "flake8<5.0.0,>=4.0.1",
-    "importlib-metadata>=1.0; python_version < \"3.8\"",
     "pygments",
     "toml",
     "urllib3",
@@ -539,7 +527,6 @@ requires_python = ">=3.7"
 summary = "GitPython is a python library used to interact with Git repositories"
 dependencies = [
     "gitdb<5,>=4.0.1",
-    "typing-extensions>=3.7.4.3; python_version < \"3.8\"",
 ]
 
 [[package]]
@@ -565,9 +552,6 @@ name = "griffe"
 version = "0.22.0"
 requires_python = ">=3.7"
 summary = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
-dependencies = [
-    "cached-property; python_version < \"3.8\"",
-]
 
 [[package]]
 name = "htmlmin"
@@ -592,7 +576,6 @@ version = "4.12.0"
 requires_python = ">=3.7"
 summary = "Read metadata from Python packages"
 dependencies = [
-    "typing-extensions>=3.6.4; python_version < \"3.8\"",
     "zipp>=0.5",
 ]
 
@@ -667,9 +650,6 @@ name = "markdown"
 version = "3.3.4"
 requires_python = ">=3.6"
 summary = "Python implementation of Markdown."
-dependencies = [
-    "importlib-metadata; python_version < \"3.8\"",
-]
 
 [[package]]
 name = "markdown-include"
@@ -841,7 +821,6 @@ summary = "Optional static typing for Python"
 dependencies = [
     "mypy-extensions>=0.4.3",
     "tomli>=1.1.0; python_version < \"3.11\"",
-    "typed-ast<2,>=1.4.0; python_version < \"3.8\"",
     "typing-extensions>=3.10",
 ]
 
@@ -920,9 +899,6 @@ name = "pluggy"
 version = "1.0.0"
 requires_python = ">=3.6"
 summary = "plugin and hook calling mechanisms for python"
-dependencies = [
-    "importlib-metadata>=0.12; python_version < \"3.8\"",
-]
 
 [[package]]
 name = "pre-commit"
@@ -932,7 +908,6 @@ summary = "A framework for managing and maintaining multi-language pre-commit ho
 dependencies = [
     "cfgv>=2.0.0",
     "identify>=1.0.0",
-    "importlib-metadata; python_version < \"3.8\"",
     "nodeenv>=0.11.1",
     "pyyaml>=5.1",
     "toml",
@@ -1015,15 +990,19 @@ summary = "Pygments is a syntax highlighting package written in Python."
 
 [[package]]
 name = "pylint"
-version = "3.0.0a4"
-requires_python = "~=3.6"
+version = "3.0.0a5"
+requires_python = ">=3.7.2"
 summary = "python code static checker"
 dependencies = [
-    "astroid<2.7,>=2.6.1",
+    "astroid<=2.12.0-dev0,>=2.11.5",
     "colorama; sys_platform == \"win32\"",
+    "dill>=0.2",
     "isort<6,>=4.2.5",
-    "mccabe<0.7,>=0.6",
-    "toml>=0.7.1",
+    "mccabe<0.8,>=0.6",
+    "platformdirs>=2.2.0",
+    "tomli>=1.1.0; python_version < \"3.11\"",
+    "tomlkit>=0.10.1",
+    "typing-extensions>=3.10.0; python_version < \"3.10\"",
 ]
 
 [[package]]
@@ -1065,7 +1044,6 @@ summary = "pytest: simple powerful testing with Python"
 dependencies = [
     "attrs>=19.2.0",
     "colorama; sys_platform == \"win32\"",
-    "importlib-metadata>=0.12; python_version < \"3.8\"",
     "iniconfig",
     "packaging",
     "pluggy<2.0,>=0.12",
@@ -1322,7 +1300,6 @@ version = "3.5.0"
 requires_python = ">=3.6"
 summary = "Manage dynamic plugins for Python applications"
 dependencies = [
-    "importlib-metadata>=1.7.0; python_version < \"3.8\"",
     "pbr!=2.1.0,>=2.0.0",
 ]
 
@@ -1342,9 +1319,6 @@ name = "tinydb"
 version = "4.7.0"
 requires_python = ">=3.6,<4.0"
 summary = "TinyDB is a tiny, document oriented database optimized for your happiness :)"
-dependencies = [
-    "typing-extensions<5.0.0,>=3.10.0; python_version <= \"3.7\"",
-]
 
 [[package]]
 name = "tinydb-serialization"
@@ -1391,11 +1365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-ast"
-version = "1.4.3"
-summary = "a fork of Python 2 and 3 ast modules with type comment support"
-
-[[package]]
 name = "types-click"
 version = "7.1.8"
 summary = "Typing stubs for click"
@@ -1420,7 +1389,6 @@ summary = "Virtual Python Environment builder"
 dependencies = [
     "distlib<1,>=0.3.1",
     "filelock<4,>=3.2",
-    "importlib-metadata>=0.12; python_version < \"3.8\"",
     "platformdirs<3,>=2",
     "six<2,>=1.9.0",
 ]
@@ -1495,7 +1463,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "4.0"
-content_hash = "sha256:715223c815138e07bff6c80670cc8d10b817fb9ae748e5fcdfe4833a2f867c0c"
+content_hash = "sha256:05e2e54036781dbf49a0dc4193a23e09ee9e0067b7618de75755667a5a577096"
 
 [metadata.files]
 "argcomplete 1.12.3" = [
@@ -1510,9 +1478,9 @@ content_hash = "sha256:715223c815138e07bff6c80670cc8d10b817fb9ae748e5fcdfe4833a2
     {url = "https://files.pythonhosted.org/packages/4c/a4/f3fbb470e9d2fc20e292e9b75e352ff0db700d463978be98fd680b72a7b0/astpretty-2.1.0-py2.py3-none-any.whl", hash = "sha256:f81f14b5636f7af81fadb1e3c09ca7702ce4615500d9cc6d6829befb2dec2e3c"},
     {url = "https://files.pythonhosted.org/packages/9a/eb/6dcf06b4289095f30aa9df423612618e5ed834e60655b2e697d2209e2633/astpretty-2.1.0.tar.gz", hash = "sha256:8a801fcda604ec741f010bb36d7cbadc3ec8a182ea6fb83e20ab663463e75ff6"},
 ]
-"astroid 2.6.6" = [
-    {url = "https://files.pythonhosted.org/packages/14/05/eca5daea3244476f10e750e0cbbc9302f3b29e354daece9659cddb471324/astroid-2.6.6-py3-none-any.whl", hash = "sha256:ab7f36e8a78b8e54a62028ba6beef7561db4cdb6f2a5009ecc44a6f42b5697ef"},
-    {url = "https://files.pythonhosted.org/packages/6d/6a/5d8f8efabad496d6caaffd7ea94e5782dde50bcf5480af72939f71114773/astroid-2.6.6.tar.gz", hash = "sha256:3975a0bd5373bdce166e60c851cfcbaf21ee96de80ec518c1f4cb3e94c3fb334"},
+"astroid 2.11.7" = [
+    {url = "https://files.pythonhosted.org/packages/47/fa/cedd4cf37634b2fcc3773cedd0a9ca05fed2fa014d3d03815b04b7738ade/astroid-2.11.7.tar.gz", hash = "sha256:bb24615c77f4837c707669d16907331374ae8a964650a66999da3f5ca68dc946"},
+    {url = "https://files.pythonhosted.org/packages/e4/3b/f1aa1bd41e8188b3a3605d71b699b73695fc7ac862cbed23ed9dee707251/astroid-2.11.7-py3-none-any.whl", hash = "sha256:86b0a340a512c65abf4368b80252754cda17c02cdbbd3f587dddf98112233e7b"},
 ]
 "asttokens 2.0.8" = [
     {url = "https://files.pythonhosted.org/packages/2d/1b/fdbdf82b86e07ca90985740ac160a1dd4ab09cb81071ec12d71c701e1138/asttokens-2.0.8-py2.py3-none-any.whl", hash = "sha256:e3305297c744ae53ffa032c45dc347286165e4ffce6875dc662b205db0623d86"},
@@ -1569,10 +1537,6 @@ content_hash = "sha256:715223c815138e07bff6c80670cc8d10b817fb9ae748e5fcdfe4833a2
 "bleach 5.0.1" = [
     {url = "https://files.pythonhosted.org/packages/c2/5d/d5d45a38163ede3342d6ac1ca01b5d387329daadf534a25718f9a9ba818c/bleach-5.0.1.tar.gz", hash = "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"},
     {url = "https://files.pythonhosted.org/packages/d4/87/508104336a2bc0c4cfdbdceedc0f44dc72da3abc0460c57e323ddd1b3257/bleach-5.0.1-py3-none-any.whl", hash = "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a"},
-]
-"cached-property 1.5.2" = [
-    {url = "https://files.pythonhosted.org/packages/48/19/f2090f7dad41e225c7f2326e4cfe6fff49e57dedb5b53636c9551f86b069/cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
-    {url = "https://files.pythonhosted.org/packages/61/2c/d21c1c23c2895c091fa7a91a54b6872098fea913526932d21902088a7c41/cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
 ]
 "certifi 2022.6.15" = [
     {url = "https://files.pythonhosted.org/packages/cc/85/319a8a684e8ac6d87a1193090e06b6bbb302717496380e225ee10487c888/certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
@@ -1745,6 +1709,10 @@ content_hash = "sha256:715223c815138e07bff6c80670cc8d10b817fb9ae748e5fcdfe4833a2
 "deepdiff 5.8.1" = [
     {url = "https://files.pythonhosted.org/packages/0f/ca/caead2949fbb824c7142e3774fa841aa853bb4d4331b440da8c8514dfc6f/deepdiff-5.8.1.tar.gz", hash = "sha256:8d4eb2c4e6cbc80b811266419cb71dd95a157094a3947ccf937a94d44943c7b8"},
     {url = "https://files.pythonhosted.org/packages/3d/98/21e6baf359f03b760331444cda25332e1d1c3911fd57a36e54029489bd91/deepdiff-5.8.1-py3-none-any.whl", hash = "sha256:e9aea49733f34fab9a0897038d8f26f9d94a97db1790f1b814cced89e9e0d2b7"},
+]
+"dill 0.3.5.1" = [
+    {url = "https://files.pythonhosted.org/packages/12/ff/3b1a8f5d59600393506c64fa14d13afdfe6fe79ed65a18d64026fe9f8356/dill-0.3.5.1-py2.py3-none-any.whl", hash = "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302"},
+    {url = "https://files.pythonhosted.org/packages/59/46/634d5316ee8984e7dac658fb2e297a19f50a1f4007b09acb9c7c4e15bd67/dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
 ]
 "distlib 0.3.5" = [
     {url = "https://files.pythonhosted.org/packages/31/d5/e2aa0aa3918c8d88c4c8e4ebbc50a840e101474b98cd83d3c1712ffe5bb4/distlib-0.3.5.tar.gz", hash = "sha256:a7f75737c70be3b25e2bee06288cec4e4c221de18455b2dd037fe2a795cab2fe"},
@@ -2292,9 +2260,9 @@ content_hash = "sha256:715223c815138e07bff6c80670cc8d10b817fb9ae748e5fcdfe4833a2
     {url = "https://files.pythonhosted.org/packages/59/0f/eb10576eb73b5857bc22610cdfc59e424ced4004fe7132c8f2af2cc168d3/Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
     {url = "https://files.pythonhosted.org/packages/5c/8e/1d9017950034297fffa336c72e693a5b51bbf85141b24a763882cf1977b5/Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
 ]
-"pylint 3.0.0a4" = [
-    {url = "https://files.pythonhosted.org/packages/3d/ff/f1a04d28efd511af3d1feec6622f072581c494cd6abe3f85769a4c354a49/pylint-3.0.0a4.tar.gz", hash = "sha256:349b149e88e4357ed4f77ac3a4e61c0ab965cda293b6f4e58caf73d4b24ae551"},
-    {url = "https://files.pythonhosted.org/packages/e7/37/b3084f49ea019330d65a26a1aaac5496b6f7b7359f4c573180c13695363e/pylint-3.0.0a4-py3-none-any.whl", hash = "sha256:adc11bec00c2084bf55c81dd69e26f2793fef757547997d44b21aed038f74403"},
+"pylint 3.0.0a5" = [
+    {url = "https://files.pythonhosted.org/packages/57/33/365b768fac1eef78717268399338ca77ca663201b4856747d5604fa5223f/pylint-3.0.0a5.tar.gz", hash = "sha256:15bc7b37f2022720765247eec24c49b93dcae6c81418adc3c36621b13d946f6d"},
+    {url = "https://files.pythonhosted.org/packages/a3/03/f8f188833f76462e1c6e9456edbf336ac24d207bb89679d0a09cb9990688/pylint-3.0.0a5-py3-none-any.whl", hash = "sha256:add6bc6380143af0f7a1ab15b5b5f54a8d9d25afc99fc7e2d86fd66f6c3e1ad9"},
 ]
 "pymdown-extensions 9.5" = [
     {url = "https://files.pythonhosted.org/packages/9e/01/96c674dd509ca427487487fdd1b0ce4a800ae716c0787411a9ac3452f67a/pymdown_extensions-9.5.tar.gz", hash = "sha256:3ef2d998c0d5fa7eb09291926d90d69391283561cf6306f85cd588a5eb5befa0"},
@@ -2527,38 +2495,6 @@ content_hash = "sha256:715223c815138e07bff6c80670cc8d10b817fb9ae748e5fcdfe4833a2
 "twine 4.0.1" = [
     {url = "https://files.pythonhosted.org/packages/08/2a/e03c20f47c750699063bbb349d68dea8990a0694f7bc65d1a97bf3254fa7/twine-4.0.1.tar.gz", hash = "sha256:96b1cf12f7ae611a4a40b6ae8e9570215daff0611828f5fe1f37a16255ab24a0"},
     {url = "https://files.pythonhosted.org/packages/38/ab/5adc82687fea5cc0414a2bb6a871ef269f8c80e808d279ee5be6fa9ad911/twine-4.0.1-py3-none-any.whl", hash = "sha256:42026c18e394eac3e06693ee52010baa5313e4811d5a11050e7d48436cf41b9e"},
-]
-"typed-ast 1.4.3" = [
-    {url = "https://files.pythonhosted.org/packages/01/08/0d92feed38a4cafe45bcbd42a2507c1900e9ec1e2e9b5e5a472f8ebfa9bb/typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
-    {url = "https://files.pythonhosted.org/packages/0d/14/d54fd856673e3a5cb230e481bcdea04976c28b691a65029a7d45aef80575/typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
-    {url = "https://files.pythonhosted.org/packages/0d/2c/947815984d0445b49cbedcca2c8e109d945facec077e034800168562dae3/typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
-    {url = "https://files.pythonhosted.org/packages/13/25/bde133fcd73e4c74e9a8de8410fe867aaca843838b83cc22304eec960fbc/typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
-    {url = "https://files.pythonhosted.org/packages/16/05/6e4328230cb16b0ae41223938f80e3cae3bbe8ae1c2aa7fe739e19bb4bc6/typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
-    {url = "https://files.pythonhosted.org/packages/21/79/b6fe6009ce744c5c282ce7926a3da69d7c89a7854b13927406ffa86bf242/typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
-    {url = "https://files.pythonhosted.org/packages/45/fb/3e55e779d1efb4ba3b0aef1212e01061462b4dd570febee57c2d33016595/typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
-    {url = "https://files.pythonhosted.org/packages/5c/3c/5633501c5cbc46a3ce495d29eed4ac43b1e864aebbeeefdcc1d372d83c81/typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
-    {url = "https://files.pythonhosted.org/packages/62/9f/55f7378ecae81cbebc586dc15d48285141a026241704b1df6f043613218f/typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
-    {url = "https://files.pythonhosted.org/packages/65/b3/573d2f1fecbbe8f82a8d08172e938c247f99abe1be3bef3da2efaa3810bf/typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
-    {url = "https://files.pythonhosted.org/packages/6e/08/c04a49ee26a94c1ec211e7b1e5f2971d692e04818ea67ef70f1e879cf525/typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
-    {url = "https://files.pythonhosted.org/packages/7e/4b/d7377c5d25b5c3b2682dada2eee1086b23842f3eb76e41063436aa4e302f/typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
-    {url = "https://files.pythonhosted.org/packages/80/47/b04cb5d1baec711c945b8543416bbbf847f9d56431c32b043bc804d6b2b8/typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
-    {url = "https://files.pythonhosted.org/packages/80/4b/e090d83d7fee2f5745863317281b84ac753c6813a4303eee29e531706347/typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
-    {url = "https://files.pythonhosted.org/packages/86/aa/29546548ed3affef704d9aabb95d7032bae8814bbf0e2323e48d353ed234/typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
-    {url = "https://files.pythonhosted.org/packages/86/b1/5f0430173eab8d2351ca03aef813f885cebf7ff583f154ae14757df89640/typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
-    {url = "https://files.pythonhosted.org/packages/96/b0/0d26e87c8beefd839e466b4b3507c8ba826b2ee8d3d7ad049618f60d3b2e/typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
-    {url = "https://files.pythonhosted.org/packages/9f/25/15113b2153fab6f3ad8c3a42169f25cb8ae9f7fee9d7201647d78eca3e91/typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
-    {url = "https://files.pythonhosted.org/packages/b2/98/c818c3024a0d44558a53941671dea7d14c690e74aa02fe2b7976d16275d1/typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
-    {url = "https://files.pythonhosted.org/packages/b4/5f/867b97f5e564c47d1755024d02ead9ea7569067aaf004f9042df1401482e/typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
-    {url = "https://files.pythonhosted.org/packages/b8/98/9f31fcc91c54b9ae80f5fa48352b6a22ed04b399037d87d0ecbca5b67d21/typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
-    {url = "https://files.pythonhosted.org/packages/bd/b5/f962ea5df10b97034cda1fe03b10a9a8cf98c4d9578592ac9254003c67bf/typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
-    {url = "https://files.pythonhosted.org/packages/c6/6f/ce968edc85a412ca4da62206a580ebf086842bf88affc4901c083b9f9411/typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
-    {url = "https://files.pythonhosted.org/packages/d0/c7/7a26ab66c32558dac761ea88d79c4175d99231db9ebb9e09c0c354bba612/typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
-    {url = "https://files.pythonhosted.org/packages/d0/cb/d70a8dd2dba6e7a2195719e1df559b6a7ec18983a3caf0ee5357d6d7a241/typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
-    {url = "https://files.pythonhosted.org/packages/d2/d9/4dc1977ae798f6081ef33d7a7c9adf73cba5e1fe503ebd4f2d0399574995/typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
-    {url = "https://files.pythonhosted.org/packages/e3/67/f42a09ead3b174437d85157dcac92e22c204380968469de356eb64d8347e/typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
-    {url = "https://files.pythonhosted.org/packages/e5/d4/12cea19d4b5b7ef124016afd4671ed10418d918bc1ff83a964036261025c/typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
-    {url = "https://files.pythonhosted.org/packages/e7/2e/c0310582bdf7aae906f866be273d1dbc90c5a8ff2e81e1b6c55af9831b1d/typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
-    {url = "https://files.pythonhosted.org/packages/f0/c7/4d9083f76c62fa9569a4efe7f89283ae56fd157f10c1961aeb06e8ab8064/typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
 ]
 "types-click 7.1.8" = [
     {url = "https://files.pythonhosted.org/packages/00/ff/0e6a56108d45c80c61cdd4743312d0304d8192482aea4cce96c554aaa90d/types-click-7.1.8.tar.gz", hash = "sha256:b6604968be6401dc516311ca50708a0a28baa7a0cb840efd7412f0dbbff4e092"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ authors = [
     {name = "Lyz", email = "lyz-code-security-advisories@riseup.net"},
 ]
 license = {text = "GPL-3.0-only"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "click>=8.1.3",
     "goodconf[yaml]>=2.0.1",
@@ -68,12 +68,6 @@ allow_prereleases = true
 
 [tool.pdm.build]
 editable-backend = "path"
-
-[tool.pdm.overrides]
-
-# To be removed once https://github.com/flakeheaven/flakeheaven/issues/55 is solved
-"importlib-metadata" = ">=3.10"
-
 
 [tool.pdm.dev-dependencies]
 lint = [

--- a/src/pynbox/entrypoints/cli.py
+++ b/src/pynbox/entrypoints/cli.py
@@ -75,7 +75,7 @@ def status(ctx: Context) -> None:
     status_data = views.status(repo, ctx.obj["config"])
     repo.close()
 
-    total_elements = sum([v for k, v in status_data.items()])
+    total_elements = sum(v for k, v in status_data.items())
     table = Table(box=box.MINIMAL_HEAVY_HEAD, show_footer=True)
 
     table.add_column("Type", justify="left", style="green", footer="Total")


### PR DESCRIPTION
To solve the dependencies now we'll use python > 3.8, it doesn't break
compatibility with 3.7 because this is going to be used to build the
pdm.lock therefore for the development environment, pip will still use
the requirements

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
